### PR TITLE
feat(api): minimal health + stub grade endpoint

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,7 @@
+module github.com/pillaiharish/protegoapi-mcp
+
+go 1.23.0
+
+toolchain go1.23.10
+
+require github.com/go-chi/chi/v5 v5.2.3

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+type GradeReq struct {
+	Code string `json:"code"`
+}
+type Finding struct {
+	Rule     string `json:"rule"`
+	Detail   string `json:"detail"`
+	Severity string `json:"severity"`
+	Passed   bool   `json:"passed"`
+}
+type GradeRes struct {
+	Pass     bool      `json:"pass"`
+	Findings []Finding `json:"findings"`
+}
+
+func main() {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+
+	// health check
+	r.Get("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+
+	// tiny stub grader: fails if code contains "SELECT * FROM"
+	r.Post("/api/grade", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var req GradeReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		res := GradeRes{
+			Pass: true,
+			Findings: []Finding{},
+		}
+		if req.Code != "" && containsSelectStar(req.Code) {
+			res.Pass = false
+			res.Findings = append(res.Findings, Finding{
+				Rule:     "SQLI-1",
+				Detail:   "Found raw 'SELECT * FROM' — avoid unsafe patterns. Use explicit columns and parameters.",
+				Severity: "high",
+				Passed:   false,
+			})
+		}
+		json.NewEncoder(w).Encode(res)
+	})
+
+	log.Println("server: http://localhost:8080")
+	log.Fatal(http.ListenAndServe(":8080", r))
+}
+
+func containsSelectStar(s string) bool {
+	return strings.Contains(strings.ToLower(s), "select * from")
+}


### PR DESCRIPTION
### Summary
Introduce a minimal Go backend using Chi with:
- GET /api/health — simple health check
- POST /api/grade — stub grader that fails if code contains "SELECT * FROM"

### Motivation
Sets up the very first runnable slice of the backend, proving that Go API wiring works and JSON responses are returned correctly. No real grading logic yet, just a naive check.

### Changes
- Added server/go.mod with Chi dependency
- Added server/main.go with basic routes
- Logs requests to console for debugging

### Testing
- Run `go run ./server`
- `curl http://localhost:8080/api/health` → returns "ok"
- `curl -X POST http://localhost:8080/api/grade -d '{"code":"SELECT * FROM"}'`
  → returns JSON with `pass: false`
- Any other code → returns JSON with `pass: true`
